### PR TITLE
Boolean logic, Strings and Character types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.class
+.classpath
+.project

--- a/Interpreter.java
+++ b/Interpreter.java
@@ -1363,6 +1363,7 @@ public class Interpreter {
         execute("let fold = fn(f, acc, ls) => if (ls) then (fold(f, f(acc, ^ls), $ls)) else (acc)");
         execute("let sum = fn(ls) => fold(fn (a, b) => a + b, 0, ls)");
         execute("let product = fn(ls) => fold(fn (a, b) => a * b, 1, ls)");
+        execute("let reverse = fn(ls) => fold(fn (rs, el) => [el] + rs, [], ls)");
     }
 
     public Atom eval(String expr) throws Exception {

--- a/Interpreter.java
+++ b/Interpreter.java
@@ -156,7 +156,11 @@ abstract class Atom {
     public Atom eq(Atom rhs) throws Exception {
         if ((this instanceof Val) && (rhs instanceof Val)) {
             return (Atom) new Bool(((Val) this).val == ((Val) rhs).val);
-        } else {
+        }
+        else if (this instanceof Bool || rhs instanceof Bool) {
+            return (Atom) new Bool(this.isTruthy() == rhs.isTruthy());
+        }
+        else {
             throw new Exception("Bad Cmp");
         }
     }

--- a/Interpreter.java
+++ b/Interpreter.java
@@ -295,11 +295,11 @@ abstract class Expr {
         Atom eval(HashMap<String, Atom> variables) throws Exception {
             if (val instanceof Atom.Ident) {
                 Atom.Ident v = (Atom.Ident) val;
-                try {
-                    return variables.get(v.name);
-                } catch (Exception e) {
+                var res = variables.get(v.name);
+                if (res == null) {
                     throw new Exception(String.format("Tried to access nonexistent variable %s", v.name));
                 }
+                return res;
             } else if (val instanceof Atom.List) {
                 Atom.List ls = (Atom.List) val;
                 ArrayList<Expr> nls = new ArrayList<>();

--- a/Interpreter.java
+++ b/Interpreter.java
@@ -166,10 +166,15 @@ abstract class Atom {
     }
 
     public Atom negate() throws Exception {
-        if (this instanceof Val) {
+    	if (this instanceof Val) {
             Val v = (Val) this;
             return (Atom) new Val(-v.val);
-        } else {
+        }
+    	else if (this instanceof Bool) {
+            Bool b = (Bool) this;
+            return (Atom) new Bool(!b.val);
+        }
+    	else {
             throw new Exception("Bad Negate");
         }
     }


### PR DESCRIPTION
## Changes
* Adds support for Boolean comparisons using the already existing `isTruthy()` method, operands are evaluated if one of them is `true` or `false`. therefore, `[] == [1]` cannot be run, but `[] == false` can and returns true, indicating that `[]` truth-value is `false`.
* Adds support for Boolean negation using the existing `-` symbol, this can be linked to mathematics where negation is indicated by `¬` which is a very similar symbol. This is a simple solution but it can be considered to implement a dedicated operator like `!` For this as in other languages.

## Discussion
Suppose you have a list `list` like in the example below:
```rust
let list = [9, 8, 7, 6]
```
And you want to extract the first element safely by first checking of the list has elements because the `^` operator throws an exception in case the operand is an empty list `Index 0 out of bounds for length 0`. This is at the moment not possible what I know as the language is lacking a `match` or `case` keyword for pattern matching? Therefore one would want to do this using `if` and with this PR, users are able to compare the *truthiness* of the list with a Boolean as follows:
```rust
let first = fn (l) => if (l == true) then (^l) else (null)
```
Now you can select the first element without the need to worry about getting an exception.
```rust
> first(list)
9
> first([])
null
```
The second part of this PR is mostly about to the negation of Boolean expressions. For this I suggest the use of the `-` prefix operator, as it is similar to the `¬` symbol in mathematics. It might wanted to consider using a **dedicated operator** for this, but to do it this way **minimizes** the size of the language and increases **expressiveness** with fewer operators.